### PR TITLE
MC-178 add explicit datadog connection spec for each function

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,14 @@ for the [Clojure](http://clojure.org) programming language.
 
 [![Clojars Project](http://clojars.org/clj-datadog/latest-version.svg)](https://clojars.org/clj-datadog)
 
+**Version `2.0.0` contains breaking changes in API and no longer accepting
+DataDog agent connection parameters through java options or environment vars.**
+
 ## Installation
 
 Include the following dependency in your project.clj file:
 
-    :dependencies [[clj-datadog "1.0.0"]]
+    :dependencies [[clj-datadog "2.0.0"]]
 
 
 ## Example Usage
@@ -28,27 +31,38 @@ Then import datadog in your namespace:
 
 Following datadog metric methods are available:
 
+### DataDog connection
+
+You have to provide a map with host and port of DataDog agent or an empty map
+to use default (`{:host "127.0.0.1" :port 8125}`).
+
+You may also create macroses like
+```clojure
+(def datadog-spec {:host "ddhost" :port 8126})
+(defmacro dd-inc [& args] `(dd/increment datadog-spec ~@args))
+(defmacro dd-dec [& args] `(dd/decrement datadog-spec ~@args))
+```
+
 ### Counters
 
-You can use iether amount or DataDog tags or both.
-Decrements are completely symmentrical to increments but
+You can use either amount or DataDog tags or both.
+Decrements are completely symmetrical to increments but
 with negative values.
 
+    (dd/increment {} "page.views")
+    (dd/increment {} "page.views" 10)
+    (dd/increment {} "error.count" {:page "products"})
+    (dd/increment {} "active.connections" 3 {:service "db"})
 
-    (dd/increment "page.views")
-    (dd/increment "page.views" 10)
-    (dd/increment "error.count" {:page "products"})
-    (dd/increment "active.connections" 3 {:service "db"})
-
-    (dd/decrement "users.online")
-    (dd/decrement "users.online" {:group "admins"})
+    (dd/decrement {} "users.online")
+    (dd/decrement {} "users.online" {:group "admins"})
 
 ### Gauges
 
 Gauges require value to be specified, but tags can be omitted
 
-    (dd/gauge "total.posts" 526)
-    (dd/gauge "total.posts" 526 {:site "main"})
+    (dd/gauge {} "total.posts" 526)
+    (dd/gauge {} "total.posts" 526 {:site "main"})
 
 ### Timers
 
@@ -57,28 +71,16 @@ will do reporting as a side-effect.
 
 In second case tags are required, even if empty.
 
-    (dd/timing "db.query.time" 843 {:query "find-by-id"})
-    (dd/timed "external.service.call" {:service service}
+    (dd/timing {} "db.query.time" 843 {:query "find-by-id"})
+    (dd/timed {} "external.service.call" {:service service}
               (http/get remote-uri {:socket-timeout timeout}))
 
+## Testing
 
-## Options
-
-By default this library sends all data to `127.0.0.1:8125`, but
-this behaviour can be changed by providing environment variables,
-like so:
-
-    DATADOG_HOST=8.8.8.8 \
-    DATADOG_PORT=2390 \
-    java -jar app.jar
-
-or via Java system properties:
-
-    java -jar app.jar \
-    -Ddatadog.host=8.8.8.8 \
-    -Ddatadog.port=2390
-
-Parameters handling is done via [environ](https://github.com/weavejester/environ) library
+To run tests do:
+```bash
+lein expectations
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Following datadog metric methods are available:
 You have to provide a map with host and port of DataDog agent or an empty map
 to use default (`{:host "127.0.0.1" :port 8125}`).
 
-You may also create macroses like
+You may also create macros like
 ```clojure
 (def datadog-spec {:host "ddhost" :port 8126})
 (defmacro dd-inc [& args] `(dd/increment datadog-spec ~@args))

--- a/project.clj
+++ b/project.clj
@@ -1,16 +1,17 @@
-(defproject clj-datadog "1.0.1"
+(defproject clj-datadog "2.0.0"
   :description "Clojure client for DataDog service via statsd protocol"
   :url "https://github.com/truckerpathteam/clj-datadog"
 
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [environ "1.0.0"]]
+  :dependencies [[org.clojure/clojure "1.7.0"]]
 
   :main ^:skip-aot clj-datadog.core
 
   :target-path "target/%s"
 
   :profiles {:uberjar {:aot :all}
-             :test {:dependencies [[expectations "2.0.9"]]}}
+             :dev {:dependencies [[expectations "2.0.9"]]}}
+
+  :plugins [[lein-expectations "0.0.8"]]
 
   ;; Artifact deployment info
   :scm {:name "git"

--- a/test/clj_datadog/core_test.clj
+++ b/test/clj_datadog/core_test.clj
@@ -9,63 +9,61 @@
   [& body]
   `(let [sended# (atom nil)]
      (with-redefs
-       [dd/send-msg (fn [value#] (reset! sended# value#))]
+       [dd/send-msg (fn [_# value#] (reset! sended# value#))]
        ~@body
        @sended#)))
 
-(deftest should-format-tags
-  (expect "|#site:main"
-          (dd/format-tags {:site :main}))
-  (expect "|#page:contacts"
-          (dd/format-tags {:page "contacts"}))
-  (expect "|#status:200"
-          (dd/format-tags {:status 200}))
-  (expect "|#error"
-          (dd/format-tags {:error nil}))
-  (expect "|#site:main,page:contacts,status:200"
-          (dd/format-tags {:site :main, :page "contacts", "status" 200})))
+;; dd/format-tags
+(expect "|#site:main"
+        (dd/format-tags {:site :main}))
+(expect "|#page:contacts"
+        (dd/format-tags {:page "contacts"}))
+(expect "|#status:200"
+        (dd/format-tags {:status 200}))
+(expect "|#error"
+        (dd/format-tags {:error nil}))
+(expect "|#site:main,page:contacts,status:200"
+        (dd/format-tags {:site :main, :page "contacts", "status" 200}))
 
-(deftest should-send-increment
-  (expect "page.views:1|c"
-            (last-sent-msg (dd/increment "page.views")))
-  (expect "page.views:7|c"
-          (last-sent-msg (dd/increment "page.views" 7)))
+;; dd/increment
+(expect "page.views:1|c"
+        (last-sent-msg (dd/increment {} "page.views")))
+(expect "page.views:7|c"
+        (last-sent-msg (dd/increment {} "page.views" 7)))
+(expect "page.views:1|c|#page:contacts"
+        (last-sent-msg (dd/increment {} "page.views" {:page "contacts"})))
+(expect "page.views:8|c|#page:contacts"
+        (last-sent-msg (dd/increment {} "page.views" 8 {:page "contacts"})))
 
-  (expect "page.views:1|c|#page:contacts"
-          (last-sent-msg (dd/increment "page.views" {:page "contacts"})))
-  (expect "page.views:8|c|#page:contacts"
-          (last-sent-msg (dd/increment "page.views" 8 {:page "contacts"}))))
+;; dd/decrement
+(expect "users.online:-1|c"
+        (last-sent-msg (dd/decrement {} "users.online")))
+(expect "users.online:-3|c"
+        (last-sent-msg (dd/decrement {} "users.online" 3)))
+(expect "users.online:-1|c|#group:admins"
+        (last-sent-msg (dd/decrement {} "users.online" {:group "admins"})))
+(expect "users.online:-5|c|#group:admins"
+        (last-sent-msg (dd/decrement {} "users.online" 5 {:group "admins"})))
 
-(deftest should-send-decrement
-  (expect "users.online:-1|c"
-          (last-sent-msg (dd/decrement "users.online")))
-  (expect "users.online:-3|c"
-          (last-sent-msg (dd/decrement "users.online" 3)))
-  (expect "users.online:-1|c|#group:admins"
-          (last-sent-msg (dd/decrement "users.online" {:group "admins"})))
-  (expect "users.online:-5|c|#group:admins"
-          (last-sent-msg (dd/decrement "users.online" 5 {:group "admins"}))))
+;; dd/gauge
+(expect "total.posts:526|g"
+        (last-sent-msg (dd/gauge {} "total.posts" 526)))
+(expect "total.posts:526|g|#site:main"
+        (last-sent-msg (dd/gauge {} "total.posts" 526 {:site "main"})))
 
-(deftest should-send-gauge
-  (expect "total.posts:526|g"
-          (last-sent-msg (dd/gauge "total.posts" 526)))
-  (expect "total.posts:526|g|#site:main"
-          (last-sent-msg (dd/gauge "total.posts" 526 {:site "main"}))))
-
-(deftest should-send-timings
-  (expect "db.query.time:576|ms"
-          (last-sent-msg (dd/timing "db.query.time" 576)))
-  (expect "db.query.time:843|ms|#query:find-by-id"
-          (last-sent-msg (dd/timing "db.query.time" 843 {:query "find-by-id"}))))
+;; dd/timing
+(expect "db.query.time:576|ms"
+        (last-sent-msg (dd/timing {} "db.query.time" 576)))
+(expect "db.query.time:843|ms|#query:find-by-id"
+        (last-sent-msg (dd/timing {} "db.query.time" 843 {:query "find-by-id"})))
 
 ;; We tested that `dd/timing` sends data correctly
 ;; So we know it works in next test, so we wont chack value
-(deftest should-measure-time
-  (expect #"something.done:\d*\|ms\|#tag:present"
-          (last-sent-msg (dd/timed "something.done" {:tag "present"}
-                                   (do (str "Whatever passed -"
-                                            "is passed")))))
-  (expect #"something.done:\d*\|ms"
-          (last-sent-msg (dd/timed "something.done" {}
-                                   (do (str "Whatever passed -"
-                                            "is passed"))))))
+(expect #"something.done:\d*\|ms\|#tag:present"
+        (last-sent-msg (dd/timed {} "something.done" {:tag "present"}
+                                 (do (str "Whatever passed -"
+                                          "is passed")))))
+(expect #"something.done:\d*\|ms"
+        (last-sent-msg (dd/timed {} "something.done" {}
+                                 (do (str "Whatever passed -"
+                                          "is passed")))))


### PR DESCRIPTION
Removed receiving datadog agent host/port through env var or java option and make it an explicit parameter for each function.